### PR TITLE
Minor improvements

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -16,6 +16,21 @@
     export AWS_SECRET_ACCESS_KEY = ***********
     ```
 
+    Make sure that your AWS user has following permissions.
+
+    ```text
+    EC2:CreateImage
+    EC2:DeleteKeyPair
+    EC2:DeleteSecurityGroup
+    EC2:DeleteSnapshot
+    EC2:DeregisterImage
+    EC2:DescribeImages
+    EC2:DescribeInstances
+    EC2:DescribeVolumes
+    EC2:StopInstances
+    EC2:TerminateInstances
+    ```
+
 2. Navigate to the image folder you plan to generate. For example, ubuntu-20-04
 
     ```sh

--- a/vmware/README.md
+++ b/vmware/README.md
@@ -3,9 +3,16 @@
 ## Prerequisites
 
 - [Packer](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli?in=packer/aws-get-started#installing-packer)
-- [OVFTool](https://developer.vmware.com/web/tool/4.4.0/ovf). Add OVFtool to your PATH as per your OS. ([Windows](https://support.us.ovhcloud.com/hc/en-us/articles/360017548080-How-to-Download-a-VM-as-an-OVF-Using-Windows#VAR))
 - VMware ([VMware Fusion](https://www.vmware.com/au/products/fusion.html) for Mac and [VMware Workstation](https://www.vmware.com/au/products/workstation-player.html) for Linux/Windows)
-- When running locally, you can download the required ISO file in the `./iso/` directory. (Download: [ubuntu-18.04.6-server-amd64.iso](https://cdimage.ubuntu.com/ubuntu/releases/18.04.6/release/ubuntu-18.04.6-server-amd64.iso)) If packer cannot find it then it'll automatically download it.
+- [OVFTool](https://developer.vmware.com/web/tool/4.4.0/ovf). Add OVFtool to your PATH as per your OS.
+  - [Windows](https://support.us.ovhcloud.com/hc/en-us/articles/360017548080-How-to-Download-a-VM-as-an-OVF-Using-Windows#VAR)
+  - For Mac, export path of your OVFtool or add it to your `.bashrc`
+
+    ```sh
+    export PATH=/Applications/VMware\ Fusion.app/Contents/Library/VMware\ OVF\ Tool/:$PATH
+    ```
+
+- When running locally, you can download the required ISO file in the `iso` directory. (Download: [ubuntu-18.04.6-server-amd64.iso](https://cdimage.ubuntu.com/ubuntu/releases/18.04.6/release/ubuntu-18.04.6-server-amd64.iso)) If packer cannot find it then it'll automatically download it.
 
 ## How to run
 

--- a/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
@@ -49,7 +49,7 @@
       "ssh_password": "vagrant",
       "tools_upload_flavor": "linux",
 
-      "headless": "{{ user `headless` }}",
+      "headless": "false",
       "guest_os_type": "ubuntu-64",
       "output_directory": "builds/packer-ubuntu-18.04-amd64-vmware",
       "skip_export": false,

--- a/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
@@ -87,7 +87,7 @@
   "variables": {
     "cpus": "2",
     "memory": "2048",
-    "disk_size": "65536",
+    "disk_size": "8192",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}"


### PR DESCRIPTION
Following minor changes:
- VMware builder: Lowered attached disk space to 8 GB
- Set `headless` var value to false to make it run on publish-pipeline
- Docs: Added least AWS User permissions for Amazon builder
- Docs: Added OVFtool PATH instructions for Mac users