### PR TITLE
Add docker installation step in RHEL 7

### DIFF
--- a/aws/rhel/rhel7/scripts/setup.sh
+++ b/aws/rhel/rhel7/scripts/setup.sh
@@ -24,4 +24,20 @@ curl https://get.tidal.sh/unix | bash
 echo ++ Installing Nmap
 sudo yum install -y nmap
 
+echo ++ Installing Docker
+
+## Install required CentOS packages
+sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse3-libs-3.6.1-4.el7.x86_64.rpm
+sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse3-devel-3.6.1-4.el7.x86_64.rpm
+sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse-overlayfs-0.7.2-6.el7_8.x86_64.rpm
+sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm
+sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/slirp4netns-0.4.3-4.el7_8.x86_64.rpm
+
+# Add docker repo and install docker engine and containerd
+sudo yum install -y yum-utils
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install -y docker-ce docker-ce-cli containerd.io
+
+docker --version
+
 echo ++++ DONE ++++

--- a/aws/rhel/rhel7/scripts/setup.sh
+++ b/aws/rhel/rhel7/scripts/setup.sh
@@ -41,7 +41,4 @@ sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/dock
 # Install Docker engine and containerd
 sudo yum install -y docker-ce docker-ce-cli containerd.io
 
-# Verify that Docker was installed
-docker --version
-
 echo ++++ DONE ++++

--- a/aws/rhel/rhel7/scripts/setup.sh
+++ b/aws/rhel/rhel7/scripts/setup.sh
@@ -26,18 +26,22 @@ sudo yum install -y nmap
 
 echo ++ Installing Docker
 
-## Install required CentOS packages
-sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse3-libs-3.6.1-4.el7.x86_64.rpm
-sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse3-devel-3.6.1-4.el7.x86_64.rpm
-sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse-overlayfs-0.7.2-6.el7_8.x86_64.rpm
-sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm
-sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/slirp4netns-0.4.3-4.el7_8.x86_64.rpm
-
-# Add docker repo and install docker engine and containerd
+# Install yum-utils
 sudo yum install -y yum-utils
+
+# Enable extras repo
+sudo yum-config-manager --enable rhel-7-server-rhui-extras-rpms
+
+# Check that repo was enabled
+sudo yum repolist enabled
+
+# Add Docker repo
 sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+
+# Install Docker engine and containerd
 sudo yum install -y docker-ce docker-ce-cli containerd.io
 
+# Verify that Docker was installed
 docker --version
 
 echo ++++ DONE ++++


### PR DESCRIPTION
This PR adds a step to install docker in the RHEL 7 script.
Since Docker is not providing support for x86_64 architecture on RHEL 7, we have used the CentOS package on RHEL.

> We currently only provide packages for RHEL on s390x (IBM Z). Other architectures are not yet supported for RHEL, but you may be able to install the CentOS packages on RHEL. Refer to the Install Docker Engine on CentOS page for details. ([source](https://docs.docker.com/engine/install/rhel/))

For more information about the installation steps: https://docs.docker.com/engine/install/centos/