### PR TITLE
Use `source_ami_filter` for RHEL 7

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -20,19 +20,19 @@ jobs:
         uses: hashicorp-contrib/setup-packer@v1
 
       - name: Publish Ubuntu-20.04 AMI
-        working-directory: ubuntu/ubuntu-20-04
+        working-directory: aws/ubuntu/ubuntu-20-04
         run: |
           packer init -upgrade ubuntu-focal.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .
 
       - name: Publish Ubuntu-18.04 AMI
-        working-directory: ubuntu/ubuntu-18-04
+        working-directory: aws/ubuntu/ubuntu-18-04
         run: |
           packer init -upgrade ubuntu-bionic.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .
       
       - name: Publish RHEL7 AMI
-        working-directory: rhel/rhel7
+        working-directory: aws/rhel/rhel7
         run: |
           packer init -upgrade rhel7.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -30,3 +30,9 @@ jobs:
         run: |
           packer init -upgrade ubuntu-bionic.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .
+      
+      - name: Publish RHEL7 AMI
+        working-directory: rhel/rhel7
+        run: |
+          packer init -upgrade rhel7.pkr.hcl
+          packer build -var-file="config.auto.pkrvars.hcl" .

--- a/aws/rhel/rhel7/config.auto.pkrvars.hcl
+++ b/aws/rhel/rhel7/config.auto.pkrvars.hcl
@@ -1,3 +1,3 @@
 aws_access_key = ""
 aws_secret_key = ""
-aws_region = "us-west-2"
+aws_region = "ca-central-1"

--- a/aws/rhel/rhel7/rhel7.pkr.hcl
+++ b/aws/rhel/rhel7/rhel7.pkr.hcl
@@ -46,6 +46,8 @@ source "amazon-ebs" "rhel7" {
     owners      = ["309956199498"]
   }
   ssh_username = "ec2-user"
+  force_deregister      = true
+  force_delete_snapshot = true
 }
 
 build {

--- a/aws/rhel/rhel7/rhel7.pkr.hcl
+++ b/aws/rhel/rhel7/rhel7.pkr.hcl
@@ -36,7 +36,15 @@ source "amazon-ebs" "rhel7" {
   region        = "${var.aws_region}"
   access_key    = "${var.aws_access_key}"
   secret_key    = "${var.aws_secret_key}"
-  source_ami    = "ami-02d40d11bb3aaf3e5"
+  source_ami_filter {
+    filters = {
+      name                = "RHEL-7*-x86_64-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["309956199498"]
+  }
   ssh_username = "ec2-user"
 }
 

--- a/aws/ubuntu/ubuntu-18-04/config.auto.pkrvars.hcl
+++ b/aws/ubuntu/ubuntu-18-04/config.auto.pkrvars.hcl
@@ -1,3 +1,3 @@
 aws_access_key = ""
 aws_secret_key = ""
-aws_region = "us-west-2"
+aws_region = "ca-central-1"

--- a/aws/ubuntu/ubuntu-20-04/config.auto.pkrvars.hcl
+++ b/aws/ubuntu/ubuntu-20-04/config.auto.pkrvars.hcl
@@ -1,3 +1,3 @@
 aws_access_key = ""
 aws_secret_key = ""
-aws_region = "us-west-2"
+aws_region = "ca-central-1"


### PR DESCRIPTION
- Replaces the hard-coded `source_ami` ID with the [source_ami_filter](https://www.packer.io/docs/builders/amazon/ebs#source_ami_filter)
- Adds the `force_deregister` and `force_delete_snapshot` to bring it up to speed with the Ubuntu packer templates
- Fixes working-directory path in the publish workflow
- Changes default region to Canada Central


This closes #13.