### PR TITLE
Add 5s wait before boot command

### DIFF
--- a/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18.04-amd64.json
@@ -14,6 +14,7 @@
       "http_directory": "http",
       "boot_wait": "5s",
       "boot_command": [
+        "<wait5s>",
         "<esc><wait>",
         "<esc><wait>",
         "<enter><wait>",


### PR DESCRIPTION
Running VMware packer builder in Azure runner prompts a never-seen-before boot menu (see image) at the beginning of the boot process. Adding a 5s wait time allows a smoother transition to the desired boot selection menu.

![image](https://user-images.githubusercontent.com/30822450/147227496-e5e8d7e5-8313-436b-a72f-559fdf6abab0.png)


While this change works well on Windows, I'd like to check it on Mac as well and make sure it doesn't have any other impacts.