### PR TITLE
WIP: Add dns-tools installation steps for ubuntu AMIs

### DIFF
--- a/aws/ubuntu/scripts/setup.sh
+++ b/aws/ubuntu/scripts/setup.sh
@@ -29,6 +29,11 @@ python3 -m pip install machine-stats
 echo ++ Installing Nmap ++
 sudo apt-get install --yes  nmap
 
+echo ++ Installing dns-tools ++
+curl --output - https://d2ny8m13pxxvfx.cloudfront.net/dns-tools/dns-tools-linux-x86_64-0.8.10.tar.gz \
+  | tar xzvf - -C /usr/local/bin --strip-components=1 --exclude=install_dns_tools.sh
+chmod a+w /usr/local/bin/lib/vendor/Gemfile.lock
+
 echo ++ Installing Docker ++
 
 # Add Docker’s official GPG key


### PR DESCRIPTION
This PR adds a step to install [dns-tools](https://dnstools.ninja/) in Ubuntu bionic and focal AMIs.

TODO:
- [ ] Verify and install the same for RHEL 7 AMI