### PR TITLE
Send slack notification on failure to release the AMIs

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,6 +1,9 @@
 name: Publish AMIs
 
 on:
+  push:
+    branches:
+      - pranav/fail-notification
   repository_dispatch:
     types:
       - publish_amis
@@ -16,26 +19,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install packer
-        uses: hashicorp-contrib/setup-packer@v1
+      # - name: Install packer
+      #   uses: hashicorp-contrib/setup-packer@v1
 
-      - name: Publish Ubuntu-20.04 AMI
-        working-directory: aws/ubuntu/ubuntu-20-04
-        run: |
-          packer init -upgrade ubuntu-focal.pkr.hcl
-          packer build -var-file="config.auto.pkrvars.hcl" .
+      # - name: Publish Ubuntu-20.04 AMI
+      #   working-directory: aws/ubuntu/ubuntu-20-04
+      #   run: |
+      #     packer init -upgrade ubuntu-focal.pkr.hcl
+      #     packer build -var-file="config.auto.pkrvars.hcl" .
 
-      - name: Publish Ubuntu-18.04 AMI
-        working-directory: aws/ubuntu/ubuntu-18-04
-        run: |
-          packer init -upgrade ubuntu-bionic.pkr.hcl
-          packer build -var-file="config.auto.pkrvars.hcl" .
+      # - name: Publish Ubuntu-18.04 AMI
+      #   working-directory: aws/ubuntu/ubuntu-18-04
+      #   run: |
+      #     packer init -upgrade ubuntu-bionic.pkr.hcl
+      #     packer build -var-file="config.auto.pkrvars.hcl" .
 
-      - name: Publish RHEL7 AMI
-        working-directory: aws/rhel/rhel7
-        run: |
-          packer init -upgrade rhel7.pkr.hcl
-          packer build -var-file="config.auto.pkrvars.hcl" .
+      # - name: Publish RHEL7 AMI
+      #   working-directory: aws/rhel/rhel7
+      #   run: |
+      #     packer init -upgrade rhel7.pkr.hcl
+      #     packer build -var-file="config.auto.pkrvars.hcl" .
+      
+      - name: This step will fail
+        run: exit 1
 
       - name: Failure Slack notification
         if: ${{ failure() }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,9 +1,6 @@
 name: Publish AMIs
 
 on:
-  push:
-    branches:
-      - pranav/fail-notification
   repository_dispatch:
     types:
       - publish_amis
@@ -19,29 +16,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # - name: Install packer
-      #   uses: hashicorp-contrib/setup-packer@v1
+      - name: Install packer
+        uses: hashicorp-contrib/setup-packer@v1
 
-      # - name: Publish Ubuntu-20.04 AMI
-      #   working-directory: aws/ubuntu/ubuntu-20-04
-      #   run: |
-      #     packer init -upgrade ubuntu-focal.pkr.hcl
-      #     packer build -var-file="config.auto.pkrvars.hcl" .
+      - name: Publish Ubuntu-20.04 AMI
+        working-directory: aws/ubuntu/ubuntu-20-04
+        run: |
+          packer init -upgrade ubuntu-focal.pkr.hcl
+          packer build -var-file="config.auto.pkrvars.hcl" .
 
-      # - name: Publish Ubuntu-18.04 AMI
-      #   working-directory: aws/ubuntu/ubuntu-18-04
-      #   run: |
-      #     packer init -upgrade ubuntu-bionic.pkr.hcl
-      #     packer build -var-file="config.auto.pkrvars.hcl" .
+      - name: Publish Ubuntu-18.04 AMI
+        working-directory: aws/ubuntu/ubuntu-18-04
+        run: |
+          packer init -upgrade ubuntu-bionic.pkr.hcl
+          packer build -var-file="config.auto.pkrvars.hcl" .
 
-      # - name: Publish RHEL7 AMI
-      #   working-directory: aws/rhel/rhel7
-      #   run: |
-      #     packer init -upgrade rhel7.pkr.hcl
-      #     packer build -var-file="config.auto.pkrvars.hcl" .
-      
-      - name: This step will fail
-        run: exit 1
+      - name: Publish RHEL7 AMI
+        working-directory: aws/rhel/rhel7
+        run: |
+          packer init -upgrade rhel7.pkr.hcl
+          packer build -var-file="config.auto.pkrvars.hcl" .
 
       - name: Failure Slack notification
         if: ${{ failure() }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -47,5 +47,5 @@ jobs:
         if: ${{ failure() }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
-          --data '{"text": "Could not build and release the Packer AMIs. Please check the workflow logs in [Infrastructure-templates](https://github.com/tidalmigrations/Infrastructure-templates) repository.", "icon_emoji": ":rocket:"}' \
+          --data '{"text": "@invalidators Failed to build and release the Packer AMIs. Please check the workflow logs in Infrastructure-templates repository."}' \
           ${{ secrets.SLACK_WEBHOOK_TIDAL_TOOLS }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -30,9 +30,16 @@ jobs:
         run: |
           packer init -upgrade ubuntu-bionic.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .
-      
+
       - name: Publish RHEL7 AMI
         working-directory: aws/rhel/rhel7
         run: |
           packer init -upgrade rhel7.pkr.hcl
           packer build -var-file="config.auto.pkrvars.hcl" .
+
+      - name: Failure Slack notification
+        if: ${{ failure() }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{"text": "Could not build and release the Packer AMIs. Please check the workflow logs in [Infrastructure-templates](https://github.com/tidalmigrations/Infrastructure-templates) repository.", "icon_emoji": ":rocket:"}' \
+          ${{ secrets.SLACK_WEBHOOK_TIDAL_TOOLS }}


### PR DESCRIPTION
Send a slack notification when failed to build/release the AMIs in the [publish-ami](https://github.com/tidalmigrations/Infrastructure-templates/blob/main/.github/workflows/publish-images.yml) workflow.