### PR TITLE
Add docker images to run tidal-tools locally

### DIFF
--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -38,6 +38,11 @@ echo \
 # Install the latest version of Docker Engine and containerd
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
-docker --version
+
+# Add docker images to run tidal-tools offline
+docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
+docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v1.0.38.x
+docker pull gcr.io/tidal-1529434400027/healthchek:latest
+docker pull gcr.io/tidal-1529434400027/hello-world:latest
 
 echo "++++ DONE ++++"


### PR DESCRIPTION
Adding Tidal's docker images to run tidal tools locally. These images are published on [gcr.io](https://cloud.google.com/container-registry/).

![image](https://user-images.githubusercontent.com/30822450/153844922-63b53c29-2dca-4e9f-8bfb-bd54298475fa.png)
