### PR TITLE
Set Windows Server's trusted hosts to all

### DIFF
--- a/aws/windows/scripts/install_additional_tools.ps1
+++ b/aws/windows/scripts/install_additional_tools.ps1
@@ -1,3 +1,8 @@
-Write-Host "++ Clone machine-stats repo ++"
+Write-Host "++ Install chrome ++"
 choco install -y googlechrome
 Start-Sleep -Seconds 40
+
+# Find more information on this here:
+# https://github.com/tidalmigrations/machine_stats/tree/master/windows#authentication-error
+Write-Host "++ Set trustedhosts to all ++"
+Set-Item WSMan:localhost\client\trustedhosts -value *

--- a/aws/windows/scripts/install_git.ps1
+++ b/aws/windows/scripts/install_git.ps1
@@ -3,11 +3,6 @@
 Write-Host "++ Checking tidal version ++"
 tidal version
 
-## Install git
-
-# Set Execution Policy
-# Set-ExecutionPolicy AllSigned
-
 # Install chocolatey
 Write-Host "++ Install chocolatey ++"
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))


### PR DESCRIPTION
This PR adds a step in the Windows Server packer builder to trust all hosts. 

```sh
Set-Item WSMan:localhost\client\trustedhosts -value *
```

This is also documented in guides of Machine Stats for Windows [here](https://github.com/tidalmigrations/machine_stats/tree/master/windows#authentication-error) and @SamDesmondKing also [came across this](https://github.com/tidalmigrations/machine_stats/pull/174#discussion_r831002191) while working on the MS4W limitations.

