### PR TITLE
Auto-approve Windows trusted hosts command

### DIFF
--- a/aws/windows/scripts/install_additional_tools.ps1
+++ b/aws/windows/scripts/install_additional_tools.ps1
@@ -5,4 +5,4 @@ Start-Sleep -Seconds 40
 # Find more information on this here:
 # https://github.com/tidalmigrations/machine_stats/tree/master/windows#authentication-error
 Write-Host "++ Set trustedhosts to all ++"
-Set-Item WSMan:localhost\client\trustedhosts -value *
+ECHO Y | Set-Item WSMan:localhost\client\trustedhosts -value * -Force


### PR DESCRIPTION
Previously, the AWS windows server template would hang during build as the trusted hosts command expects user confirmation. 

This PR adds the `-Force` flag to this command to bypass this.