### PR TITLE
Build VMWare appliance with Machine Stats Alpha

### DIFF
--- a/vmware/README.md
+++ b/vmware/README.md
@@ -31,11 +31,18 @@
 
 3. (Optional) If you want to follow the build process in GUI, then you need to turn the `headless` bool to `false` in the `ubuntu-18-04-amd64.json` file.
 
-4. Build the packer template by running this command
+4. Build the packer template by running one of these commands:
+   - **Option A**: To build the appliance with [Machine Stats' stable version](https://pypi.org/project/machine-stats/).
 
-   ```sh
-   packer build ubuntu-18.04-amd64.json
-   ```
+      ```sh
+      packer build ubuntu-18.04-amd64.json
+      ```
+
+   - **Option B**: To build the appliance with [Machine Stats Alpha](https://pypi.org/project/machine-stats-alpha/).
+
+      ```sh
+      packer build ubuntu-18.04-amd64-alpha.json
+      ```
 
 5. This will take 20 to 80 minutes based on your OS and machine. Grab a coffee and appreciate life. At the end of the process, the OVA will be at `./builds/packer-ubuntu-18-04-amd64-vmware/tidal-ubuntu-18-04-server-amd64.ova` along with a few other files. If you're running the packer template again, the `packer-ubuntu-18-04-amd64-vmware` directory must not exist or be empty.
 

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -16,8 +16,8 @@ python3 -m pip install --upgrade pip
 echo "++ Installing jq"
 sudo apt-get install --yes jq
 
-echo "++ Installing Machine-Stats"
-python3 -m pip install machine-stats
+echo "++ Installing Machine-Stats Alpha"
+python3 -m pip install machine-stats-alpha
 
 echo "++ Installing Nmap"
 sudo apt-get install --yes  nmap

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -43,7 +43,7 @@ sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
-docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v1.0.38.x
+docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.0.x
 docker pull gcr.io/tidal-1529434400027/healthchek:latest
 docker pull gcr.io/tidal-1529434400027/hello-world:latest
 

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -43,7 +43,7 @@ sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
-docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v1.0.38.x
+docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.0.x
 docker pull gcr.io/tidal-1529434400027/healthchek:latest
 docker pull gcr.io/tidal-1529434400027/hello-world:latest
 

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
@@ -52,7 +52,7 @@
 
       "headless": "true",
       "guest_os_type": "ubuntu-64",
-      "output_directory": "builds/packer-ubuntu-18-04-amd64-vmware-alpha",
+      "output_directory": "builds/packer-ubuntu-18-04-amd64-vmware",
       "skip_export": false
     }
   ],  

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
@@ -1,0 +1,89 @@
+{
+  "builders": [
+    {
+      "type": "vmware-iso",
+      "vm_name": "tidal-ubuntu-18-04-server-amd64-alpha",
+      "format": "ova",
+
+      "iso_urls": [
+        "iso/ubuntu-18.04.6-server-amd64.iso",
+        "https://cdimage.ubuntu.com/ubuntu/releases/18.04.6/release/ubuntu-18.04.6-server-amd64.iso"
+      ],
+      "iso_checksum": "file:http://cdimage.ubuntu.com/ubuntu/releases/18.04.6/release/SHA256SUMS",
+
+      "http_directory": "http",
+      "boot_wait": "5s",
+      "boot_command": [
+        "<wait5s>",
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US.UTF-8<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US.UTF-8<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=ubuntu<wait>",
+        " grub-installer/bootdev=/dev/sda<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "shutdown_command": "echo 'tidal' | sudo -S shutdown -P now",
+
+      "cpus": "{{ user `cpus` }}",
+      "memory": "{{ user `memory` }}",
+      "disk_size": "{{user `disk_size`}}",
+
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "ubuntu",
+      "ssh_password": "tidal",
+      "tools_upload_flavor": "linux",
+
+      "headless": "true",
+      "guest_os_type": "ubuntu-64",
+      "output_directory": "builds/packer-ubuntu-18-04-amd64-vmware-alpha",
+      "skip_export": false
+    }
+  ],  
+  "provisioners": [
+    {
+      "environment_vars": [
+        "HOME_DIR=/home/ubuntu",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'tidal' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "{{template_dir}}/scripts/update.sh",
+        "{{template_dir}}/scripts/sshd.sh",
+        "{{template_dir}}/scripts/networking.sh",
+        "{{template_dir}}/scripts/sudoers.sh",
+        "{{template_dir}}/scripts/vmware.sh",
+        "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/scripts/tidal-ubuntu-1804-alpha.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "cpus": "2",
+    "memory": "2048",
+    "disk_size": "8192",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "no_proxy": "{{env `no_proxy`}}"
+  }
+}


### PR DESCRIPTION
This PR adds an additional VMWare packer builder file `ubuntu-18-04-amd64-alpha.json` to create a separate appliance with the [alpha version of Machine Stats](https://pypi.org/project/machine-stats-alpha/). To build the appliance with different machine stats versions, you'll have to run different packer builders. i.e.,

- To create the OVA file with the stable/main version of machine stats, run
  ```sh
    packer build ubuntu-18.04-amd64.json
  ```

- - To create the OVA file with the alpha version of machine stats, run
  ```sh
    packer build ubuntu-18.04-amd64-alpha.json
  ```