### PR TITLE
Add docker to Windows OVA

### DIFF
--- a/vmware/windows-server-2022/scripts/tidal/enable_docker_to_non_root_user.ps1
+++ b/vmware/windows-server-2022/scripts/tidal/enable_docker_to_non_root_user.ps1
@@ -1,0 +1,7 @@
+# Install dockeraccesshelper module to allow
+# docker access to non-root user
+# Source: https://github.com/tfenster/dockeraccesshelper
+Install-Module -Name dockeraccesshelper -Force
+
+# Add vagrant user for docker access
+Add-AccountToDockerAccess "\vagrant"

--- a/vmware/windows-server-2022/scripts/tidal/install_docker.ps1
+++ b/vmware/windows-server-2022/scripts/tidal/install_docker.ps1
@@ -1,0 +1,5 @@
+# Install docker module
+Install-Module -Name DockerMsftProvider -Repository PSGallery -Confirm:$False -Force
+
+# Install docker package
+Install-Package -Name docker -ProviderName DockerMsftProvider -Force

--- a/vmware/windows-server-2022/windows-2022.json
+++ b/vmware/windows-server-2022/windows-2022.json
@@ -91,6 +91,25 @@
         "{{template_dir}}/scripts/tidal/install_machine_stats.ps1",
         "{{template_dir}}/scripts/tidal/install_additional_tools.ps1"
       ]
+    },
+    {
+      "elevated_password": "vagrant",
+      "elevated_user": "Administrator",
+      "type": "powershell",
+      "scripts": [
+        "{{template_dir}}/scripts/tidal/install_docker.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "elevated_password": "vagrant",
+      "elevated_user": "vagrant",
+      "type": "powershell",
+      "scripts": [
+        "{{template_dir}}/scripts/tidal/enable_docker_to_non_root_user.ps1"
+      ]
     }
   ],
   "variables": {

--- a/vmware/windows-server-2022/windows-2022.json
+++ b/vmware/windows-server-2022/windows-2022.json
@@ -105,7 +105,7 @@
     },
     {
       "elevated_password": "vagrant",
-      "elevated_user": "vagrant",
+      "elevated_user": "Administrator",
       "type": "powershell",
       "scripts": [
         "{{template_dir}}/scripts/tidal/enable_docker_to_non_root_user.ps1"


### PR DESCRIPTION
Contains changes to add docker in the Windows OVA image. Docker is installed through with the `Administrator` user, however, [dockeraccesshelper](https://github.com/tfenster/dockeraccesshelper) module is used to allow access to non-root user (`vagrant`).

### Docker running from the `vagrant` user
![image](https://user-images.githubusercontent.com/30822450/180397348-fba4582a-70d4-40bf-ad88-4b938c80e14b.png)

### Errors while adding tidal images (WIP)
The PR does not yet add the tidal images. Error log 👇 

![image](https://user-images.githubusercontent.com/30822450/180397161-8e67876e-315f-4767-b901-60c938084855.png)
