### PR TITLE
Change Windows OVA's ID/Pass

### DIFF
--- a/vmware/windows-server-2022/cookbooks/packer/recipes/cleanup.rb
+++ b/vmware/windows-server-2022/cookbooks/packer/recipes/cleanup.rb
@@ -48,7 +48,7 @@ powershell_script 'remove unnecesary directories' do
       "$env:windir\\logs",
       "$env:windir\\temp",
       "$env:windir\\winsxs\\manifestcache",
-      "C:\\Users\\vagrant\Favorites\\*"
+      "C:\\Users\\tidal\Favorites\\*"
   ) | % {
           if(Test-Path $_) {
               Write-Host "Removing $_"

--- a/vmware/windows-server-2022/scripts/unattended/Autounattend.xml
+++ b/vmware/windows-server-2022/scripts/unattended/Autounattend.xml
@@ -114,8 +114,8 @@
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
-                <FullName>Vagrant</FullName>
-                <Organization>Bento by Chef Software, Inc.</Organization>
+                <FullName>TidalMigrations</FullName>
+                <Organization>TidalMigrations</Organization>
             </UserData>
         </component>
     </settings>
@@ -150,28 +150,28 @@
       <TimeZone>UTC</TimeZone>
       <UserAccounts>
         <AdministratorPassword>
-          <Value>vagrant</Value>
+          <Value>tidal</Value>
           <PlainText>true</PlainText>
         </AdministratorPassword>
         <LocalAccounts>
           <LocalAccount wcm:action="add">
             <Password>
-              <Value>vagrant</Value>
+              <Value>tidal</Value>
               <PlainText>true</PlainText>
             </Password>
-            <Description>Vagrant User</Description>
-            <DisplayName>vagrant</DisplayName>
+            <Description>Tidal User</Description>
+            <DisplayName>tidal</DisplayName>
             <Group>administrators</Group>
-            <Name>vagrant</Name>
+            <Name>tidal</Name>
           </LocalAccount>
         </LocalAccounts>
       </UserAccounts>
             <AutoLogon>
                 <Password>
-                    <Value>vagrant</Value>
+                    <Value>tidal</Value>
                     <PlainText>true</PlainText>
                 </Password>
-                <Username>vagrant</Username>
+                <Username>tidal</Username>
                 <Enabled>true</Enabled>
             </AutoLogon>
       <FirstLogonCommands>
@@ -266,9 +266,9 @@
               <RequiresUserInput>true</RequiresUserInput>
           </SynchronousCommand>
           <SynchronousCommand wcm:action="add">
-              <CommandLine>cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE</CommandLine>
+              <CommandLine>cmd.exe /c wmic useraccount where "name='tidal'" set PasswordExpires=FALSE</CommandLine>
               <Order>16</Order>
-              <Description>Disable password expiration for vagrant user</Description>
+              <Description>Disable password expiration for tidal user</Description>
           </SynchronousCommand>
       </FirstLogonCommands>
     </component>

--- a/vmware/windows-server-2022/windows-2022.json
+++ b/vmware/windows-server-2022/windows-2022.json
@@ -28,9 +28,9 @@
       "tools_upload_flavor": "windows",
       "tools_upload_path": "c:/Windows/Temp/vmware.iso",
       "version": 19,
-      "winrm_password": "vagrant",
+      "winrm_password": "tidal",
       "winrm_timeout": "12h",
-      "winrm_username": "vagrant"
+      "winrm_username": "tidal"
     }
   ],
   "provisioners": [
@@ -76,14 +76,14 @@
       "type": "chef-solo"
     },
     {
-      "elevated_password": "vagrant",
-      "elevated_user": "vagrant",
+      "elevated_password": "tidal",
+      "elevated_user": "tidal",
       "script": "{{template_dir}}/scripts/common/cleanup.ps1",
       "type": "powershell"
     },
     {
-      "elevated_password": "vagrant",
-      "elevated_user": "vagrant",
+      "elevated_password": "tidal",
+      "elevated_user": "tidal",
       "type": "powershell",
       "scripts": [
         "{{template_dir}}/scripts/tidal/install_tidal_tools.ps1",


### PR DESCRIPTION
This PR changes the credentials of both the users, `tidal` and `Administrator`.

### Old creds:

```text
Username: vagrant
Password: vagrant

Username: Administrator
Password: vagrant
```

### New creds:

```text
Username: tidal
Password: tidal

Username: Administrator
Password: tidal
```

PR to update the same 👆 in our guides: https://github.com/tidalmigrations/tidalmigrations.github.io/pull/216