### PR TITLE
Ubuntu OVA: Add `ubuntu` user to the docker group

### DIFF
--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -41,6 +41,10 @@ echo \
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
+# Add `ubuntu` to docker group
+sudo groupadd docker
+sudo usermod -aG docker ubuntu
+
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -44,6 +44,7 @@ sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 # Add `ubuntu` to docker group
 sudo groupadd docker
 sudo usermod -aG docker ubuntu
+sudo chmod 666 /var/run/docker.sock
 
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -41,6 +41,10 @@ echo \
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
+# Add `ubuntu` to docker group
+sudo groupadd docker
+sudo usermod -aG docker ubuntu
+
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -44,6 +44,7 @@ sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 # Add `ubuntu` to docker group
 sudo groupadd docker
 sudo usermod -aG docker ubuntu
+sudo chmod 666 /var/run/docker.sock
 
 # Add docker images to run tidal-tools offline
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest


### PR DESCRIPTION
The `ubuntu` user requires access to docker when running tidal tools, thus this PR adds the `ubuntu` user to the docker group as it is also recommended in our guides [here](https://guides.tidalmg.com/troubleshooting.html#docker-non-root).