### PR TITLE
Ubuntu OVA: Fix adding `ubuntu` to docker group

### DIFF
--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -42,7 +42,7 @@ sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add `ubuntu` to docker group
-sudo groupadd docker
+sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -37,16 +37,16 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Install the latest version of Docker Engine and containerd
+echo "Install the latest version of Docker Engine and containerd"
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
-# Add `ubuntu` to docker group
+echo "Add ubuntu user to docker group"
 sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 
-# Add docker images to run tidal-tools offline
+echo "Add docker images to run tidal-tools offline"
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1
 docker pull gcr.io/tidal-1529434400027/healthchek:latest

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -37,16 +37,16 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Install the latest version of Docker Engine and containerd
+echo "Install the latest version of Docker Engine and containerd"
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
-# Add `ubuntu` to docker group
+echo "Add ubuntu user to docker group"
 sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 
-# Add docker images to run tidal-tools offline
+echo "Add docker images to run tidal-tools offline"
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1
 docker pull gcr.io/tidal-1529434400027/healthchek:latest

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -3,7 +3,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "++ Installing Tidal Tools"
 curl https://get.tidal.sh/unix | bash
-su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
 
 echo "++ Installing PIP"
 sudo apt-get install --yes python3-pip

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -3,6 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "++ Installing Tidal Tools"
 curl https://get.tidal.sh/unix | bash
+su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
 
 echo "++ Installing PIP"
 sudo apt-get install --yes python3-pip
@@ -42,7 +43,7 @@ sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add `ubuntu` to docker group
-sudo groupadd docker
+sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 


### PR DESCRIPTION
While adding the `ubuntu` user in the docker group in Ubuntu OVA, we already have the `docker` group, so the build from PR #48 was failing because of this error. 

![image](https://user-images.githubusercontent.com/30822450/186719487-e98a3ffd-8355-40e1-a030-3112d6b00738.png)

Instead of removing the command, I have added the force flag here since it gracefully exits if the group already exists.

![image](https://user-images.githubusercontent.com/30822450/186720605-978defd3-2905-4873-ae33-3e268c2352d5.png)

I have also converted some of the comments into echo so that they can be searched easily in the large packer log file.