### PR TITLE
Ubuntu OVA: Install tidal tools for ubuntu user

### DIFF
--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -42,7 +42,7 @@ sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add `ubuntu` to docker group
-sudo groupadd docker
+sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -1,7 +1,10 @@
 #!/bin/sh -eux
 export DEBIAN_FRONTEND=noninteractive
 
-echo "++ Installing Tidal Tools"
+echo "++ Installing Tidal Tools for ubuntu user"
+su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
+
+echo "++ Installing Tidal Tools for root user"
 curl https://get.tidal.sh/unix | bash
 
 echo "++ Installing PIP"

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804-alpha.sh
@@ -37,16 +37,16 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Install the latest version of Docker Engine and containerd
+echo "Install the latest version of Docker Engine and containerd"
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
-# Add `ubuntu` to docker group
+echo "Add ubuntu user to docker group"
 sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 
-# Add docker images to run tidal-tools offline
+echo "Add docker images to run tidal-tools offline"
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1
 docker pull gcr.io/tidal-1529434400027/healthchek:latest

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -1,7 +1,10 @@
 #!/bin/sh -eux
 export DEBIAN_FRONTEND=noninteractive
 
-echo "++ Installing Tidal Tools"
+echo "++ Installing Tidal Tools for ubuntu user"
+su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
+
+echo "++ Installing Tidal Tools for root user"
 curl https://get.tidal.sh/unix | bash
 
 echo "++ Installing PIP"

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -37,16 +37,16 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Install the latest version of Docker Engine and containerd
+echo "Install the latest version of Docker Engine and containerd"
 sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
-# Add `ubuntu` to docker group
+echo "Add ubuntu user to docker group"
 sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 
-# Add docker images to run tidal-tools offline
+echo "Add docker images to run tidal-tools offline"
 docker pull gcr.io/tidal-1529434400027/cast-highlight:latest
 docker pull gcr.io/tidal-1529434400027/tidal-db-analyzer:v3.1.1
 docker pull gcr.io/tidal-1529434400027/healthchek:latest

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -3,7 +3,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "++ Installing Tidal Tools"
 curl https://get.tidal.sh/unix | bash
-su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
 
 echo "++ Installing PIP"
 sudo apt-get install --yes python3-pip

--- a/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
+++ b/vmware/ubuntu-18-04/scripts/tidal-ubuntu-1804.sh
@@ -3,6 +3,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 echo "++ Installing Tidal Tools"
 curl https://get.tidal.sh/unix | bash
+su - ubuntu -c "curl https://get.tidal.sh/unix | bash"
 
 echo "++ Installing PIP"
 sudo apt-get install --yes python3-pip
@@ -42,7 +43,7 @@ sudo apt-get update
 sudo apt-get install --yes docker-ce docker-ce-cli containerd.io
 
 # Add `ubuntu` to docker group
-sudo groupadd docker
+sudo groupadd docker --force
 sudo usermod -aG docker ubuntu
 sudo chmod 666 /var/run/docker.sock
 


### PR DESCRIPTION
Tidal tools was available for both users, but it wasn't possible for the `ubuntu` user to update it to the latest version. This PR fixes that. This PR should only be merged in after #49.

**Before:**
![image](https://user-images.githubusercontent.com/30822450/186886619-87a09392-e688-419d-a044-564d387821c3.png)

**After:**
![image](https://user-images.githubusercontent.com/30822450/186886688-b0068e3a-c598-4681-9e8e-8f947867d52f.png)
![image](https://user-images.githubusercontent.com/30822450/186886815-48e4759e-27de-4013-b104-4b6b2d85632d.png)


