### PR TITLE
Ubuntu OVA: Increase RAM/Storage and add swap memory

### DIFF
--- a/vmware/ubuntu-18-04/scripts/swapfile.sh
+++ b/vmware/ubuntu-18-04/scripts/swapfile.sh
@@ -1,0 +1,13 @@
+# Disable existing swap
+sudo swapoff -a
+
+# Create a swap of 2GB
+sudo fallocate -l 2G /swapfile
+
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+sudo sed -i '$a/swapfile swap swap defaults 0 0' /etc/fstab
+
+# Show free memory
+sudo free -h

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
@@ -73,6 +73,7 @@
         "{{template_dir}}/scripts/sudoers.sh",
         "{{template_dir}}/scripts/vmware.sh",
         "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/scripts/swapfile.sh",
         "{{template_dir}}/scripts/tidal-ubuntu-1804-alpha.sh"
       ],
       "type": "shell"

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
@@ -73,6 +73,7 @@
         "{{template_dir}}/scripts/sudoers.sh",
         "{{template_dir}}/scripts/vmware.sh",
         "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/scripts/swapfile.sh",
         "{{template_dir}}/scripts/tidal-ubuntu-1804.sh"
       ],
       "type": "shell"

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
@@ -81,7 +81,7 @@
   "variables": {
     "cpus": "2",
     "memory": "4096",
-    "disk_size": "8192",
+    "disk_size": "16384",
     "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
@@ -50,7 +50,7 @@
       "ssh_password": "tidal",
       "tools_upload_flavor": "linux",
 
-      "headless": "true",
+      "headless": "{{ user `headless` }}",
       "guest_os_type": "ubuntu-64",
       "output_directory": "builds/packer-ubuntu-18-04-amd64-vmware",
       "skip_export": false
@@ -80,8 +80,9 @@
   ],
   "variables": {
     "cpus": "2",
-    "memory": "2048",
+    "memory": "4096",
     "disk_size": "8192",
+    "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "no_proxy": "{{env `no_proxy`}}"


### PR DESCRIPTION
With the existing RAM size of the Ubuntu OVA file, it can cause the `Out of memory` exception when running multiple tools and software. Thus, this PR increases the RAM size from 2 GB to 4 GB.
There was an existing swap memory of 980 MB. This PR also adds another 2 GB of swap memory as suggested by Ubuntu [here](https://help.ubuntu.com/community/SwapFaq#:~:text=reduced%20or%20eliminated.-,How%20much%20swap%20do%20I%20need%3F).

**Caution:** Our total swap memory (2.9 GB) is not more than the total RAM (4 GB), thus it is not advised that you [hibernate](https://www.linuxandubuntu.com/home/how-to-enable-hibernate-in-ubuntu-linux) the appliance. Hibernation requires at least the same amount of swap memory as your RAM and we have not yet validated the OVA for it.

FYI the [swappiness](https://help.ubuntu.com/community/SwapFaq#What_is_swappiness_and_how_do_I_change_it.3F:~:text=defaults%200%200-,What%20is%20swappiness%20and%20how%20do%20I%20change%20it%3F,-The%20swappiness%20parameter) parameter is kept to its default value of `60`.

WIP: I am building the OVA appliance file and yet to validate and release it.

### Before
![image](https://user-images.githubusercontent.com/30822450/188559833-b1e65912-77d0-4d6d-a3f6-dc2d8d3e9387.png)

### After
![image](https://user-images.githubusercontent.com/30822450/188559619-29a26710-c38b-4b2b-97da-eaef657cc4a3.png)


