### PR TITLE
Fix Ubuntu OVA creation

### DIFF
--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64-alpha.json
@@ -48,7 +48,6 @@
       "ssh_timeout": "10000s",
       "ssh_username": "ubuntu",
       "ssh_password": "tidal",
-      "tools_upload_flavor": "linux",
 
       "headless": "{{ user `headless` }}",
       "guest_os_type": "ubuntu-64",

--- a/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
+++ b/vmware/ubuntu-18-04/ubuntu-18-04-amd64.json
@@ -48,7 +48,6 @@
       "ssh_timeout": "10000s",
       "ssh_username": "ubuntu",
       "ssh_password": "tidal",
-      "tools_upload_flavor": "linux",
 
       "headless": "{{ user `headless` }}",
       "guest_os_type": "ubuntu-64",


### PR DESCRIPTION
The Ubuntu OVA creation process was failing because of the property `tools_uplaod_flavor`. As per the docs [here](https://developer.hashicorp.com/packer/plugins/builders/vmware/iso#tools_upload_flavor), removing this property will stop uploading the VMware tools to the VM. However, the OVA can still be imported into the VMware workstation even without the preinstalled VMware tools, so this PR removes the `tools_uplaod_flavor` property from the Ubuntu packer file.

### Validate the new Ubuntu OVA
![image](https://user-images.githubusercontent.com/30822450/205611044-0f294d02-315a-488b-ae85-46c1ce8720bb.png)

### Errors
![image](https://user-images.githubusercontent.com/30822450/205603730-bb199c22-7f9d-4f58-9ec7-788395575135.png)
<!-- ![image2](https://user-images.githubusercontent.com/30822450/205603814-6a494184-4c15-4fdb-bef9-c4271fc705eb.png) -->

